### PR TITLE
Fix running rspec in CI (failure for unknonwn reason)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,4 +23,4 @@ jobs:
           sudo apt-get -y install google-chrome-stable
       - name: Run single browser spec to check sanity
         run: |
-          rspec spec/functional/helpcenter_main_page_links_spec.rb
+          bundle exec rspec spec/functional/helpcenter_main_page_links_spec.rb


### PR DESCRIPTION
Same fix as https://github.com/ONLYOFFICE-QA/testing-site-onlyoffice/pull/2111

Those errors appeared from yesterday
Rootcause not sure, probably some minor issue in bundler, but easily fixed

Failures like those:
```
/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:2121:in `method_missing': undefined method `ignored?' for an instance of Gem::Specification (NoMethodError)
	from /opt/hostedtoolcache/Ruby/3.3.[5](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:6)/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/rubygems_ext.rb:273:in `reject'
	from /opt/hostedtoolcache/Ruby/3.3.5/x[6](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:7)4/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/rubygems_ext.rb:273:in `matching_specs'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/dependency.rb:293:in `to_specs'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:1020:in `map'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:1020:in `unresolved_specs'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:998:in `find_in_unresolved'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:92:in `block in require'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:39:in `synchronize'
	from <internal:/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:39:in `require'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.1/lib/rspec/support/source.rb:56:in `ast'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.1/lib/rspec/support/source.rb:[7](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:8)3:in `nodes_by_line_number'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/snippet_extractor.rb:11[8](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:9):in `location_nodes_at_beginning_line'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/snippet_extractor.rb:[9](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:10)6:in `expression_node'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/snippet_extractor.rb:88:in `line_range_of_location_nodes_in_expression'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/snippet_extractor.rb:57:in `line_range_of_expression'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/snippet_extractor.rb:42:in `expression_lines'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/snippet_extractor.rb:31:in `extract_expression_lines_at'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:248:in `read_failed_lines'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:171:in `failure_slash_error_lines'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:158:in `block in failure_lines'
	from <internal:kernel>:90:in `tap'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:157:in `failure_lines'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:34:in `colorized_message_lines'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:274:in `formatted_message_and_backtrace'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:93:in `fully_formatted_lines'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/formatters/exception_presenter.rb:85:in `fully_formatted'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/reporter.rb:169:in `notify_non_example_exception'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:2154:in `rescue in load_file_handling_errors'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:2138:in `load_file_handling_errors'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:1638:in `block in load_spec_files'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:1636:in `each'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:1636:in `load_spec_files'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:[10](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:11)2:in `setup'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:86:in `run'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:71:in `run'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:45:in `invoke'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/exe/rspec:4:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/bin/rspec:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/bin/rspec:25:in `<main>'
/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:2[12](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:13)1:in `method_missing': undefined method `ignored?' for an instance of Gem::Specification (NoMethodError)
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/rubygems_ext.rb:273:in `reject'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/rubygems_ext.rb:273:in `matching_specs'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/dependency.rb:293:in `to_specs'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:1020:in `map'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:1020:in `unresolved_specs'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/rubygems/specification.rb:998:in `find_in_unresolved'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/rubygems_ext.rb:298:in `<module:Gem>'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/rubygems_ext.rb:25:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler.rb:10:in `require_relative'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler.rb:10:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/setup.rb:6:in `require_relative'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/bundler-2.5.22/lib/bundler/setup.rb:6:in `<top (required)>'
	from /home/runner/work/testing-helpcenter/testing-helpcenter/lib/testing-helpcenter/help_center_test_instance.rb:3:in `<top (required)>'
	from /home/runner/work/testing-helpcenter/testing-helpcenter/lib/testing_helpcenter.rb:6:in `require_relative'
	from /home/runner/work/testing-helpcenter/testing-helpcenter/lib/testing_helpcenter.rb:6:in `<top (required)>'
	from /home/runner/work/testing-helpcenter/testing-helpcenter/spec/spec_helper.rb:3:in `require_relative'
	from /home/runner/work/testing-helpcenter/testing-helpcenter/spec/spec_helper.rb:3:in `<top (required)>'
	from /home/runner/work/testing-helpcenter/testing-helpcenter/spec/functional/helpcenter_main_page_links_spec.rb:3:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.[13](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:14).1/lib/rspec/core/configuration.rb:2139:in `load'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:2139:in `load_file_handling_errors'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:1638:in `block in load_spec_files'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:[16](https://github.com/ONLYOFFICE-QA/testing-helpcenter/actions/runs/11400247546/job/31720688387#step:6:17)36:in `each'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/configuration.rb:1636:in `load_spec_files'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:102:in `setup'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:86:in `run'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:71:in `run'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/lib/rspec/core/runner.rb:45:in `invoke'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.1/exe/rspec:4:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/bin/rspec:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.3.5/x64/bin/rspec:25:in `<main>'
No examples found.
```

Not sure why this happens, but seems just running rspec via bundler solves it