### PR TITLE
Run CI on production helpcenter, not a dev one

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,4 +23,4 @@ jobs:
           sudo apt-get -y install google-chrome-stable
       - name: Run single browser spec to check sanity
         run: |
-          bundle exec rspec spec/functional/heplcenter_pop_up_tags_spec.rb
+          SPEC_REGION='com' bundle exec rspec spec/functional/heplcenter_pop_up_tags_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 * Check `dependabot` at 8:00 Moscow time daily
 * Fix `rubocop-1.28.1` code issues
 * Remove `ruby-3.1` from CI
+* Run CI on production helpcenter, not a dev one


### PR DESCRIPTION
No point to check dev site, it can be broken in any part CI check stability of tests themself, not the quality of product it tests